### PR TITLE
Fix Outputs circular JSON stringification issues.

### DIFF
--- a/src/js/GulpCloudformation.js
+++ b/src/js/GulpCloudformation.js
@@ -165,7 +165,7 @@ const GulpCloudformation = Class.extend(Obj, {
         .map(({OutputKey, OutputValue}) => {
             return {[OutputKey]: OutputValue};
         })
-        .scan(Object.assign, {});
+        .scan((acc, value) => Object.assign(acc, value), {});
     },
 
     hasStack(params) {


### PR DESCRIPTION
The RX scan props were present in the object being serialized because
the Object.assign is merging all the parameters and one of those
was the actual RX scan internal instance (containig properties like
'source', 'hasSeed', 'seed').
